### PR TITLE
Update PXC versions

### DIFF
--- a/sources/operator.1.5.0.pxc-operator.json
+++ b/sources/operator.1.5.0.pxc-operator.json
@@ -6,12 +6,12 @@
       "matrix": {
         "pxc": {
           "8.0.19-10.1": {
-            "image_path": "percona/percona-xtradb-cluster:8.0.19",
+            "image_path": "percona/percona-xtradb-cluster:8.0.19-10.1",
             "image_hash": "7025f539c3fe4b7ca9ba280c944f39da85bfb680080243480d5a13961fc81554",
             "status": "recommended",
             "critical": false
           },
-          "8.0.18-9": {
+          "8.0.18-9.3": {
             "image_path": "percona/percona-xtradb-cluster:8.0.18-9.3",
             "image_hash": "7025f539c3fe4b7ca9ba280c944f39da85bfb680080243480d5a13961fc81554",
             "status": "recommended",
@@ -38,12 +38,6 @@
           "5.7.26-31.37": {
             "image_path": "percona/percona-xtradb-cluster:5.7.26-31.37",
             "image_hash": "9d43d8e435e4aca5c694f726cc736667cb938158635c5f01a0e9412905f1327f",
-            "status": "available",
-            "critical": false
-          },
-          "5.7.25-31.35": {
-            "image_path": "percona/percona-xtradb-cluster:5.7.25-31.35",
-            "image_hash": "78460483e99c093d2910d3667d928ed8c2165165554482058875bccafa4ccf0b",
             "status": "available",
             "critical": false
           }


### PR DESCRIPTION
IIRC it was said that 5.7.25 PXC image cannot work with operator since image is incompatible so removed.
Other change is to make versions consistent (full version instead of only part).