### PR TITLE
PXCO release 1.7.0

### DIFF
--- a/sources/operator.1.7.0.pxc-operator.json
+++ b/sources/operator.1.7.0.pxc-operator.json
@@ -105,13 +105,13 @@
         "backup": {
           "8.0.22": {
             "image_path": "percona/percona-xtradb-cluster-operator:1.7.0-pxc8.0-backup",
-            "image_hash": "5ce65acd74d29d4c63ef5bb3dfac70700f8ddb8ca533084702c796efdf0050ff",
+            "image_hash": "2c49d5693836c1226ea0fe775111dcfc78cd51ec557f8f3ea79cf30b674ef8cf",
             "status": "recommended",
             "critical": false
           },
           "2.4.21": {
             "image_path": "percona/percona-xtradb-cluster-operator:1.7.0-pxc5.7-backup",
-            "image_hash": "91a5041103586eec9a23c59761b143a7080bb0b45dc8cd06fb575a48dd4bf846",
+            "image_hash": "15d6318f401bd024fcdab4c04448d162aac59a04c7162c61c43b88f63af08676",
             "status": "recommended",
             "critical": false
           }

--- a/sources/operator.1.7.0.pxc-operator.json
+++ b/sources/operator.1.7.0.pxc-operator.json
@@ -111,7 +111,7 @@
           },
           "2.4.21": {
             "image_path": "percona/percona-xtradb-cluster-operator:1.7.0-pxc5.7-backup",
-            "image_hash": "cc9b9174a1c0b492b549a4967389164c23e95138f1adf761cc75676113036f1e",
+            "image_hash": "bba24798031ee76a7d01bf87319c58853f625373b97615c5ff610c8d11c800d7",
             "status": "recommended",
             "critical": false
           }


### PR DESCRIPTION
This was the last update of PXC backup image hashes (they are already included in the version service because the build was done from this branch).