### PR TITLE
PMM-8170 Add pmm-server as a product

### DIFF
--- a/api-tests/apply_route_test.go
+++ b/api-tests/apply_route_test.go
@@ -343,6 +343,20 @@ func TestApplyPsmdbReturnedVersions(t *testing.T) {
 	}
 }
 
+func TestPmmServerUnimplemented(t *testing.T) {
+	cli := cli()
+
+	params := &version_service.VersionServiceApplyParams{
+		Apply:           "latest",
+		OperatorVersion: "1.8.0",
+		Product:         "pmm-server",
+	}
+	params.WithTimeout(2 * time.Second)
+
+	_, err := cli.VersionService.VersionServiceApply(params)
+	assert.Error(t, err, "error expected - apply should not be implemented for pmm-server")
+}
+
 func getVersion(v map[string]models.VersionVersion) string {
 	for k := range v {
 		return k

--- a/api-tests/operator_route_test.go
+++ b/api-tests/operator_route_test.go
@@ -144,3 +144,29 @@ func TestOperatorRoutePgShouldReturnNotEmptyResponses(t *testing.T) {
 		assert.Greater(t, len(resp.Payload.Versions[0].Matrix.Pgbouncer), 0)
 	}
 }
+
+func TestOperatorRoutePMMServerShouldReturnNotEmptyResponses(t *testing.T) {
+	cli := cli()
+
+	cases := []struct {
+		product string
+		version string
+	}{
+		{"pmm-server", "2.19.0"},
+	}
+
+	for _, c := range cases {
+		params := &version_service.VersionServiceOperatorParams{
+			OperatorVersion: c.version,
+			Product:         c.product,
+		}
+		params.WithTimeout(2 * time.Second)
+
+		resp, err := cli.VersionService.VersionServiceOperator(params)
+		assert.NoError(t, err)
+
+		assert.Len(t, resp.Payload.Versions, 1)
+		assert.Len(t, resp.Payload.Versions[0].Matrix.PxcOperator, 1)
+		assert.Len(t, resp.Payload.Versions[0].Matrix.PsmdbOperator, 1)
+	}
+}

--- a/api-tests/product_route_test.go
+++ b/api-tests/product_route_test.go
@@ -17,6 +17,7 @@ func TestProductRouteShouldReturnRigthProductName(t *testing.T) {
 		{"pxc-operator"},
 		{"psmdb-operator"},
 		{"postgresql-operator"},
+		{"pmm-server"},
 	}
 
 	for _, c := range cases {

--- a/api/version.proto
+++ b/api/version.proto
@@ -134,6 +134,8 @@ message VersionMatrix {
   map<string, Version> pgbackrest_repo = 11;
   map<string, Version> pgbadger = 12;
   map<string, Version> pgbouncer = 13;
+  map<string, Version> pxc_operator = 14;
+  map<string, Version> psmdb_operator = 15;
 }
 
 // OperatorVersion represents operator version.

--- a/api/version.swagger.yaml
+++ b/api/version.swagger.yaml
@@ -437,6 +437,14 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/versionVersion'
+      pxcOperator:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/versionVersion'
+      psmdbOperator:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/versionVersion'
     description: VersionMatrix represents set of possible product versions.
   versionVersionResponse:
     type: object

--- a/server/server.go
+++ b/server/server.go
@@ -25,11 +25,11 @@ func (b *Backend) Product(ctx context.Context, req *pbVersion.ProductRequest) (*
 }
 
 func (b *Backend) Operator(ctx context.Context, req *pbVersion.OperatorRequest) (*pbVersion.OperatorResponse, error) {
-	team := "operator"
+	productFamily := "operator"
 	if req.Product == pmmServerProduct {
-		team = "pmm"
+		productFamily = "pmm"
 	}
-	vs, err := operatorProductData(team, req.Product, req.OperatorVersion)
+	vs, err := operatorProductData(productFamily, req.Product, req.OperatorVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const pmmServerProduct = "pmm-server"
+
 // Backend implements the protobuf interface.
 type Backend struct {
 }
@@ -23,7 +25,11 @@ func (b *Backend) Product(ctx context.Context, req *pbVersion.ProductRequest) (*
 }
 
 func (b *Backend) Operator(ctx context.Context, req *pbVersion.OperatorRequest) (*pbVersion.OperatorResponse, error) {
-	vs, err := operatorProductData(req.Product, req.OperatorVersion)
+	team := "operator"
+	if req.Product == pmmServerProduct {
+		team = "pmm"
+	}
+	vs, err := operatorProductData(team, req.Product, req.OperatorVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -34,12 +40,16 @@ func (b *Backend) Operator(ctx context.Context, req *pbVersion.OperatorRequest) 
 }
 
 func (b *Backend) Apply(_ context.Context, req *pbVersion.ApplyRequest) (*pbVersion.VersionResponse, error) {
+	if req.Product == pmmServerProduct {
+		return nil, status.Error(codes.Unimplemented, "not implemented for pmm-server")
+	}
+
 	err := transformRequest(req)
 	if err != nil {
 		return nil, err
 	}
 
-	vs, err := operatorProductData(req.Product, req.OperatorVersion)
+	vs, err := operatorProductData("operator", req.Product, req.OperatorVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/server/source.go
+++ b/server/source.go
@@ -38,8 +38,6 @@ func init() {
 	}
 }
 
-const pmmServerSuffix = ".pmm-server.json"
-
 func operatorData(product string) (*pbVersion.ProductResponse, error) {
 	suffix := fmt.Sprintf(".%s.json", product)
 	r := pbVersion.ProductResponse{}

--- a/server/source.go
+++ b/server/source.go
@@ -38,6 +38,8 @@ func init() {
 	}
 }
 
+const pmmServerSuffix = ".pmm-server.json"
+
 func operatorData(product string) (*pbVersion.ProductResponse, error) {
 	suffix := fmt.Sprintf(".%s.json", product)
 	r := pbVersion.ProductResponse{}
@@ -65,8 +67,8 @@ func operatorData(product string) (*pbVersion.ProductResponse, error) {
 	return &r, nil
 }
 
-func operatorProductData(product string, operatorVersion string) (*pbVersion.VersionResponse, error) {
-	source := fmt.Sprintf("operator.%s.%s.json", operatorVersion, product)
+func operatorProductData(team string, product string, version string) (*pbVersion.VersionResponse, error) {
+	source := fmt.Sprintf("%s.%s.%s.json", team, version, product)
 	v, ok := data[source]
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "no such source file: %s", source)

--- a/server/source.go
+++ b/server/source.go
@@ -65,8 +65,8 @@ func operatorData(product string) (*pbVersion.ProductResponse, error) {
 	return &r, nil
 }
 
-func operatorProductData(team string, product string, version string) (*pbVersion.VersionResponse, error) {
-	source := fmt.Sprintf("%s.%s.%s.json", team, version, product)
+func operatorProductData(productFamily string, product string, version string) (*pbVersion.VersionResponse, error) {
+	source := fmt.Sprintf("%s.%s.%s.json", productFamily, version, product)
 	v, ok := data[source]
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "no such source file: %s", source)

--- a/sources/pmm.2.19.0.pmm-server.json
+++ b/sources/pmm.2.19.0.pmm-server.json
@@ -1,0 +1,26 @@
+{
+  "versions": [
+    {
+      "operator": "2.19.0",
+      "product": "pmm-server",
+      "matrix": {
+        "pxcOperator": {
+          "1.8.0": {
+            "image_path": "percona/percona-xtradb-cluster-operator:1.8.0",
+            "image_hash": "8ae74434882f19f3b7bc324d1ba1cb62ab405b63f654147b559c86571fd184e2",
+            "status": "recommended",
+            "critical": false
+          }
+        },
+        "psmdbOperator": {
+          "1.8.0": {
+            "image_path": "percona/percona-server-mongodb-operator:1.8.0",
+            "image_hash": "c9d8253acb97d2bfe3d1cf1120216d20565da4eb5dfd0f3f6385bab7eeea2110",
+            "status": "recommended",
+            "critical": false
+          }
+        }
+      }
+    }
+  ]
+}

--- a/third_party/OpenAPI/api/version.swagger.yaml
+++ b/third_party/OpenAPI/api/version.swagger.yaml
@@ -437,6 +437,14 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/versionVersion'
+      pxcOperator:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/versionVersion'
+      psmdbOperator:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/versionVersion'
     description: VersionMatrix represents set of possible product versions.
   versionVersionResponse:
     type: object


### PR DESCRIPTION
To be able to see what operator versions are compatible with DBaaS, which is part of pmm-server, we add pmm-server as a new product.
Basically, two routes are added with this change:
GET /versions/v1/pmm-server
GET /versions/v1/pmm-server/2.19.0 