### PR TITLE
Add PMM server 2.20.0 dependencies on operators

### DIFF
--- a/sources/pmm.2.20.0.pmm-server.json
+++ b/sources/pmm.2.20.0.pmm-server.json
@@ -1,0 +1,26 @@
+{
+  "versions": [
+    {
+      "operator": "2.20.0",
+      "product": "pmm-server",
+      "matrix": {
+        "pxcOperator": {
+          "1.8.0": {
+            "image_path": "percona/percona-xtradb-cluster-operator:1.8.0",
+            "image_hash": "8ae74434882f19f3b7bc324d1ba1cb62ab405b63f654147b559c86571fd184e2",
+            "status": "recommended",
+            "critical": false
+          }
+        },
+        "psmdbOperator": {
+          "1.8.0": {
+            "image_path": "percona/percona-server-mongodb-operator:1.8.0",
+            "image_hash": "c9d8253acb97d2bfe3d1cf1120216d20565da4eb5dfd0f3f6385bab7eeea2110",
+            "status": "recommended",
+            "critical": false
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
PMM server 2.20.0 is in development. We need this to test out our new features regarding updating operators.