### PR TITLE
PMM-8355 Add support of PSMDB operator 1.9.0 to pmm-server 2.21.0

### DIFF
--- a/sources/pmm.2.21.0.pmm-server.json
+++ b/sources/pmm.2.21.0.pmm-server.json
@@ -1,0 +1,32 @@
+{
+  "versions": [
+    {
+      "operator": "2.21.0",
+      "product": "pmm-server",
+      "matrix": {
+        "pxcOperator": {
+          "1.8.0": {
+            "image_path": "percona/percona-xtradb-cluster-operator:1.8.0",
+            "image_hash": "8ae74434882f19f3b7bc324d1ba1cb62ab405b63f654147b559c86571fd184e2",
+            "status": "recommended",
+            "critical": false
+          }
+        },
+        "psmdbOperator": {
+          "1.8.0": {
+            "image_path": "percona/percona-server-mongodb-operator:1.8.0",
+            "image_hash": "c9d8253acb97d2bfe3d1cf1120216d20565da4eb5dfd0f3f6385bab7eeea2110",
+            "status": "available",
+            "critical": false
+          },
+          "1.9.0": {
+            "image_path": "percona/percona-server-mongodb-operator:1.9.0",
+            "image_hash": "2daab5999a3a5bc407cc63ce8ae4d18d985f636685273c6678b118d770c3c014",
+            "status": "recommended",
+            "critical": false
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
We needed to change [dbaas-controller](https://github.com/percona-platform/dbaas-controller/pull/202) to support the new operator. That is why support goes to 2.21.0 and not to 2.20.0 which has already reached end of development.