### PR TITLE
rollback to psmdb 1.11 as recommended version

### DIFF
--- a/sources/pmm.2.29.0.pmm-server.json
+++ b/sources/pmm.2.29.0.pmm-server.json
@@ -28,13 +28,13 @@
           "1.11.0": {
             "image_path": "percona/percona-server-mongodb-operator:1.11.0",
             "image_hash": "662a64a539a23a8bbad653c71af3bee3dd1038ea575e1d67293b9e2ad4a1d3f1",
-            "status": "available",
+            "status": "recommended",
             "critical": false
           },
           "1.12.0": {
             "image_path": "percona/percona-server-mongodb-operator:1.12.0",
             "image_hash": "e9ed11994cef3f7ab33e126484d5d5991cccc00b54d066183d1c7abe8e29b802",
-            "status": "recommended",
+            "status": "available",
             "critical": false
           }
         }


### PR DESCRIPTION
Need use 1.11 as recommended due to https://jira.percona.com/browse/PMM-10012 