### PR TITLE
Remove PSMDB 1.12 from old PMM versions.

### DIFF
--- a/sources/pmm.2.27.0.pmm-server.json
+++ b/sources/pmm.2.27.0.pmm-server.json
@@ -48,12 +48,6 @@
             "image_hash": "662a64a539a23a8bbad653c71af3bee3dd1038ea575e1d67293b9e2ad4a1d3f1",
             "status": "available",
             "critical": false
-          },
-          "1.12.0": {
-            "image_path": "percona/percona-server-mongodb-operator:1.12.0",
-            "image_hash": "e9ed11994cef3f7ab33e126484d5d5991cccc00b54d066183d1c7abe8e29b802",
-            "status": "recommended",
-            "critical": false
           }
         }
       }

--- a/sources/pmm.2.28.0.pmm-server.json
+++ b/sources/pmm.2.28.0.pmm-server.json
@@ -48,12 +48,6 @@
             "image_hash": "662a64a539a23a8bbad653c71af3bee3dd1038ea575e1d67293b9e2ad4a1d3f1",
             "status": "available",
             "critical": false
-          },
-          "1.12.0": {
-            "image_path": "percona/percona-server-mongodb-operator:1.12.0",
-            "image_hash": "e9ed11994cef3f7ab33e126484d5d5991cccc00b54d066183d1c7abe8e29b802",
-            "status": "recommended",
-            "critical": false
           }
         }
       }


### PR DESCRIPTION
1.12 isn't supported by already released PMM versions.