### PR TITLE
Fix PXC image tag for PXC operator v1.12.0

### DIFF
--- a/sources/operator.1.12.0.pxc-operator.json
+++ b/sources/operator.1.12.0.pxc-operator.json
@@ -6,7 +6,7 @@
       "matrix": {
         "pxc": {
           "8.0.31-23.2": {
-            "image_path": "perconalab/percona-xtradb-cluster:8.0.31-23.2",
+            "image_path": "percona/percona-xtradb-cluster:8.0.31-23.2",
             "image_hash": "e47110307e9733fbcc55e5587652e41bbcf794063b021533d5e705062da97927",
             "status": "recommended",
             "critical": false


### PR DESCRIPTION
PR #140 introduced a PXC image tag that doesn't seem to exist.
It references `perconalab/percona-xtradb-cluster:8.0.31-23.2` but the image exists under the `percona` organization.
https://hub.docker.com/layers/percona/percona-xtradb-cluster/8.0.31-23.2/images/sha256-ed1ceea0b594ae34a92c891b4e42bc543d24999c82e47382cf53e33be4ae1d71