### PR TITLE
K8SPG-597 Add all images from 2.3.1 (#255)

### DIFF
--- a/sources/operator.2.4.0.pg-operator.json
+++ b/sources/operator.2.4.0.pg-operator.json
@@ -8,31 +8,65 @@
           "12.19": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg12.19-postgres",
             "image_hash": "170f11a418e5fa2962ab94570d5d132d40184101c844f82e5e4aa9d4fd8e7a69",
+            "status": "recommended",
+            "critical": false
+          },
+          "12.17": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg12-postgres",
+            "image_hash": "f65fec42a82c937ea0ce1b25898a245d469375ed6ffddd2a396a032c86ccc2ee",
             "status": "available",
             "critical": false
           },
+
           "13.15": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg13.15-postgres",
             "image_hash": "8b805570442447394be88edefdefbbc4edfc9d10f094840708756e3dc4a2f518",
+            "status": "recommended",
+            "critical": false
+          },
+          "13.13": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg13-postgres",
+            "image_hash": "e6fd0b1f84d9ecf1baab04b477720ae46faf7f1df031b36dcf4eb94b4bdfc0d1",
             "status": "available",
             "critical": false
           },
+
           "14.12": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg14.12-postgres",
             "image_hash": "121f25cc4477014708f72e642a3866ceea3dbefc950b3a3c08e1b665cce6e9f6",
+            "status": "recommended",
+            "critical": false
+          },
+          "14.10": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg14-postgres",
+            "image_hash": "8476acea85f323f8f22e96c1aef59d84ad3997b2ccc3b1ab9d3eb70b734d5f8c",
             "status": "available",
             "critical": false
           },
+
           "15.7": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg15.7-postgres",
             "image_hash": "8d58c8e9d7c54849854027c36905c149fa1db5ea4e8d13b3e6cb69d6e8128c7f",
+            "status": "recommended",
+            "critical": false
+          },
+          "15.5": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg15-postgres",
+            "image_hash": "a8ef34191c6d29f93f4a9fdde3f97f89284d67726719c94f1f7f14bd2312677e",
             "status": "available",
             "critical": false
           },
+
           "16.3": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg16.3-postgres",
             "image_hash": "8248b290a88b881f1871fbca0de7da1acace31f94f795d1990e3ca3ca5dd3636",
             "status": "recommended",
+            "critical": false
+          },
+          "16.1": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg16-postgres",
+            "image_hash": "2f329755dda215e233512c6e453a850bfc7505a7dfceb3a6ed64b8b84e532c15",
+            "status": "available",
             "critical": false
           }
         },
@@ -48,31 +82,66 @@
           "12.19": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg12.19-pgbackrest2.51-1",
             "image_hash": "93ec75d2158f5df7d69ee88578fde31fb8aab660ce6f3d5b19a83efe0c5fae33",
+            "status": "recommended",
+            "critical": false
+          },
+          "12.17": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg12-pgbackrest",
+            "image_hash": "3c1f34a752238496d70ce08c765e24416a7d9fa13771ad7088a9440385deb262",
             "status": "available",
             "critical": false
           },
+
           "13.15": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg13.15-pgbackrest2.51-1",
             "image_hash": "420d1cadee0ef7ff8a6e1044b46a0258a78ce0f53c196ff79eb17938f882c912",
+            "status": "recommended",
+            "critical": false
+          },
+          "13.13": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg13-pgbackrest",
+            "image_hash": "d659a6a6f2cd29425fb929c22226e5f48572bd83cca33a8cdb5d22846dd70299",
             "status": "available",
             "critical": false
           },
+
           "14.12": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg14.12-pgbackrest2.51-1",
             "image_hash": "77159b971e7b1473d3d0fbe173ba73fce5b8b853538d4d238a0eab9d96ccea87",
+            "status": "recommended",
+            "critical": false
+          },
+          "14.10": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg14-pgbackrest",
+            "image_hash": "6033cbe86bf52b407196e5a5810b6323d5490fca68bb795d1e2192b27ba6dbc9",
             "status": "available",
             "critical": false
           },
+
+
           "15.7": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg15.7-pgbackrest2.51-1",
             "image_hash": "2949859f8095ddcb246c5754973bd93d9bd4dafd7b649b94a9859ffa585cfc78",
+            "status": "recommended",
+            "critical": false
+          },
+          "15.5": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg15-pgbackrest",
+            "image_hash": "74679b3698b6b56a224280703c6423a13eb975f73f8cae6072ff6e523ba9db30",
             "status": "available",
             "critical": false
           },
+
           "16.3": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg16.3-pgbackrest2.51-1",
             "image_hash": "3e59b19b619e5580292c4fa8f9efedea3e9d05b79af8e186643490b13a6f83a5",
             "status": "recommended",
+            "critical": false
+          },
+          "16.1": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg16-pgbackrest",
+            "image_hash": "1c0271c06be6df3a02235f76364c2f7e92471f8b08385ed78219811bcce5338f",
+            "status": "available",
             "critical": false
           }
         },
@@ -80,31 +149,65 @@
           "12.19": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg12.19-pgbouncer1.22.1",
             "image_hash": "cd3bcc3a1575c320177ab56b5f861f418b222e6de438240d54f016343ca2d716",
+            "status": "recommended",
+            "critical": false
+          },
+          "12.17": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg12-pgbouncer",
+            "image_hash": "2613992361e9b6fa7aa037a139c069ce9c7b6a2282cdb586782511ec4213bfaf",
             "status": "available",
             "critical": false
           },
+
           "13.15": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg13.15-pgbouncer1.22.1",
             "image_hash": "a6dc61d46304c859791759b06b3d46bb991943efb6362693a954d6bb1d287db1",
+            "status": "recommended",
+            "critical": false
+          },
+          "13.13": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg13-pgbouncer",
+            "image_hash": "7569a872d999803f53b795a18babd897bfac8ce5aa20e09c4c10be1c643a9399",
             "status": "available",
             "critical": false
           },
+
           "14.12": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg14.12-pgbouncer1.22.1",
             "image_hash": "b2ad8723fbd6a9d59ef57812fc1a31ac7971ef17acba7334ad35647069f0531f",
+            "status": "recommended",
+            "critical": false
+          },
+          "14.10": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg14-pgbouncer",
+            "image_hash": "d7b3756b42ded49defc1a5e3641fbeec18d4f3ac4e498c96999c55e764412240",
             "status": "available",
             "critical": false
           },
+
           "15.7": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg15.7-pgbouncer1.22.1",
             "image_hash": "5b17a53c505010b83b477086f3491e444df8fddae6946e42e3a22679aaf8c35e",
+            "status": "recommended",
+            "critical": false
+          },
+          "15.5": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg15-pgbouncer",
+            "image_hash": "8b3f138102f19c9f04c02d1eda409c44a7894ea66108bbc4b18b61ed4b002c60",
             "status": "available",
             "critical": false
           },
+
           "16.3": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg16.3-pgbouncer1.22.1",
             "image_hash": "37f466cea2330939f16c890a327b1d88b16cd85063ce45aff8255b8108accb08",
             "status": "recommended",
+            "critical": false
+          },
+          "16.1": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg16-pgbouncer",
+            "image_hash": "6b6ceba33c3105a40e43bc8e47cd24d6379373dbd6fc25970d46b69b528fcd59",
+            "status": "available",
             "critical": false
           }
         },
@@ -112,31 +215,65 @@
           "12.19": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg12.19-postgres-gis3.3.6",
             "image_hash": "cc908441eb50e7bf9e9237b82be8877be391195643be83bcda818db16e626448",
+            "status": "recommended",
+            "critical": false
+          },
+          "12.17": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg12-postgres-gis",
+            "image_hash": "876daa942c3f564b87d9af0bb2d17fca52b377f7f65d6fae8ac876f061ae3c9b",
             "status": "available",
             "critical": false
           },
+
           "13.15": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg13.15-postgres-gis3.3.6",
             "image_hash": "d02d03a344947c1fead11cea06898a569c774a9c6393df88c4245f26882b3552",
+            "status": "recommended",
+            "critical": false
+          },
+          "13.13": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg13-postgres-gis",
+            "image_hash": "f35605252375afc6c9126f0bedc1f3cc6bfa79cbb6bf14dd85eb9f949c030201",
             "status": "available",
             "critical": false
           },
+
           "14.12": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg14.12-postgres-gis3.3.6",
             "image_hash": "7ca244090edfa24bc33fa81ac1e315669771639a1fc0a5e4525f5b5df8a22400",
+            "status": "recommended",
+            "critical": false
+          },
+          "14.10": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg14-postgres-gis",
+            "image_hash": "5d307ea8925187413b77eb7767abe699b977cfa5e2448a7bc74ce150648e61c2",
             "status": "available",
             "critical": false
           },
+
           "15.7": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg15.7-postgres-gis3.3.6",
             "image_hash": "cbb2b249aee4fb1281f81947fdc191b0d2e737345d1d35dee7d1a98a9118de40",
+            "status": "recommended",
+            "critical": false
+          },
+          "15.5": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg15-postgres-gis",
+            "image_hash": "7bb8c9c5c077e376d45822e77924f8f1f44a06d4e239cfe2d360e91fbe71a25c",
             "status": "available",
             "critical": false
           },
+
           "16.3": {
             "image_path": "percona/percona-postgresql-operator:2.4.0-ppg16.3-postgres-gis3.3.6",
             "image_hash": "7ca3172329ade3be97b9bd837a3315fcb87179357e420f76662a9d0e9a4a74d3",
             "status": "recommended",
+            "critical": false
+          },
+          "16.1": {
+            "image_path": "percona/percona-postgresql-operator:2.3.1-ppg16-postgres-gis",
+            "image_hash": "9277a9c3b3e69865c293e671a834299866357adb8237e787283569be1faec714",
+            "status": "available",
             "critical": false
           }
         },


### PR DESCRIPTION
* K8SPG-597 Add all images from 2.3.1

* sorting it like it is in the other operators, eg. 12.19, 12.17, 13.15, 13.13..., adding latest recommended versions for 12.x, 13.x, 14.x and 15.x

* adding pgbackrest, pgbouncer and postgis images for each database as well and also not have just one recommended, but the same as in databases