### PR TITLE
Everest 1.1.0-rc1 - remove k8s version requirement

### DIFF
--- a/sources/metadata/everest/1.1.0-rc1.yaml
+++ b/sources/metadata/everest/1.1.0-rc1.yaml
@@ -1,4 +1,3 @@
 version: 1.1.0-rc1
 supported:
   cli: '>= 1.0.0'
-  kubernetes: '>= 1.27'


### PR DESCRIPTION
Since we decide to postpone the operators upgrade that motivated this restriction to 1.2.0 we no longer need to enforce it.