### PR TITLE
Update PXC operator with 1.18.0 images (#425)

### DIFF
--- a/api-tests/apply_route_test.go
+++ b/api-tests/apply_route_test.go
@@ -18,7 +18,7 @@ func TestApplyShouldReturnJustOneVersion(t *testing.T) {
 
 	pxcParams := &version_service.VersionServiceApplyParams{
 		Apply:           "latest",
-		OperatorVersion: "1.17.0",
+		OperatorVersion: "1.18.0",
 		Product:         "pxc-operator",
 	}
 	pxcParams.WithTimeout(2 * time.Second)
@@ -30,7 +30,7 @@ func TestApplyShouldReturnJustOneVersion(t *testing.T) {
 	assert.Len(t, pxcResp.Payload.Versions[0].Matrix.Pxc, 1)
 	assert.Len(t, pxcResp.Payload.Versions[0].Matrix.Backup, 1)
 	assert.Len(t, pxcResp.Payload.Versions[0].Matrix.Proxysql, 1)
-	assert.Len(t, pxcResp.Payload.Versions[0].Matrix.Pmm, 1)
+	assert.Len(t, pxcResp.Payload.Versions[0].Matrix.Pmm, 2)
 	assert.Len(t, pxcResp.Payload.Versions[0].Matrix.Haproxy, 1)
 	assert.Len(t, pxcResp.Payload.Versions[0].Matrix.Operator, 1)
 
@@ -62,7 +62,7 @@ func TestApplyShouldReturnJustOneVersion(t *testing.T) {
 
 	assert.Len(t, pgResp.Payload.Versions, 1)
 	assert.Len(t, pgResp.Payload.Versions[0].Matrix.Postgresql, 1)
-	assert.Len(t, pgResp.Payload.Versions[0].Matrix.Pmm, 4)
+	assert.Len(t, pgResp.Payload.Versions[0].Matrix.Pmm, 2)
 	assert.Len(t, pgResp.Payload.Versions[0].Matrix.Pgbackrest, 1)
 	assert.Len(t, pgResp.Payload.Versions[0].Matrix.Pgbouncer, 1)
 	assert.Len(t, pgResp.Payload.Versions[0].Matrix.Postgis, 1)
@@ -92,12 +92,12 @@ func TestApplyPxcShouldReturnSameMajorVersion(t *testing.T) {
 
 	pxcParams := &version_service.VersionServiceApplyParams{
 		Apply:           "latest",
-		OperatorVersion: "1.17.0",
+		OperatorVersion: "1.18.0",
 		Product:         "pxc-operator",
 	}
 	pxcParams.WithTimeout(2 * time.Second)
 
-	for _, v := range []string{"5.7", "8.0"} {
+	for _, v := range []string{"5.7", "8.0", "8.4"} {
 		pxcParams.DatabaseVersion = &v
 		pxcResp, err := cli.VersionService.VersionServiceApply(pxcParams)
 		assert.NoError(t, err)
@@ -171,6 +171,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 	cli := cli()
 
 	v57 := "5.7"
+	v80 := "8.0"
 	vPreRel := "5.7.31-99-99"
 
 	cases := []struct {
@@ -180,6 +181,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		version   string
 	}{
 		// test latest
+		{"latest", "1.18.0", nil, "8.4.5-5.1"},
 		{"latest", "1.17.0", nil, "8.0.41-32.1"},
 		{"latest", "1.16.1", nil, "8.0.39-30.1"},
 		{"latest", "1.16.0", nil, "8.0.39-30.1"},
@@ -197,6 +199,8 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"latest", "1.6.0", nil, "8.0.20-11.2"},
 		{"latest", "1.5.0", nil, "8.0.20-11.2"},
 		{"latest", "1.4.0", nil, "8.0.18-9.3"},
+		{"latest", "1.18.0", &v80, "8.0.42-33.1"},
+		{"latest", "1.18.0", &v57, "5.7.44-31.65"},
 		{"latest", "1.17.0", &v57, "5.7.44-31.65"},
 		{"latest", "1.16.1", &v57, "5.7.44-31.65"},
 		{"latest", "1.16.0", &v57, "5.7.44-31.65"},
@@ -216,6 +220,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"latest", "1.4.0", &v57, "5.7.28-31.41.2"},
 
 		// test latest when prerelease part in current version is bigger than in latest
+		{"latest", "1.18.0", &vPreRel, "5.7.44-31.65"},
 		{"latest", "1.17.0", &vPreRel, "5.7.44-31.65"},
 		{"latest", "1.16.1", &vPreRel, "5.7.44-31.65"},
 		{"latest", "1.16.0", &vPreRel, "5.7.44-31.65"},
@@ -234,6 +239,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"latest", "1.5.0", &vPreRel, "5.7.31-31.45.2"},
 
 		// test recommended
+		{"recommended", "1.18.0", nil, "8.0.42-33.1"},
 		{"recommended", "1.17.0", nil, "8.0.41-32.1"},
 		{"recommended", "1.16.1", nil, "8.0.39-30.1"},
 		{"recommended", "1.16.0", nil, "8.0.39-30.1"},
@@ -251,6 +257,8 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"recommended", "1.6.0", nil, "8.0.20-11.2"},
 		{"recommended", "1.5.0", nil, "8.0.20-11.2"},
 		{"recommended", "1.4.0", nil, "8.0.18-9.3"},
+		{"recommended", "1.18.0", &v80, "8.0.42-33.1"},
+		{"recommended", "1.18.0", &v57, "5.7.44-31.65"},
 		{"recommended", "1.17.0", &v57, "5.7.44-31.65"},
 		{"recommended", "1.16.1", &v57, "5.7.44-31.65"},
 		{"recommended", "1.16.0", &v57, "5.7.44-31.65"},
@@ -270,6 +278,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"recommended", "1.4.0", &v57, "5.7.28-31.41.2"},
 
 		// test exact
+		{"5.7.36-31.55", "1.18.0", nil, "5.7.36-31.55"},
 		{"5.7.36-31.55", "1.17.0", nil, "5.7.36-31.55"},
 		{"5.7.36-31.55", "1.16.1", nil, "5.7.36-31.55"},
 		{"5.7.36-31.55", "1.16.0", nil, "5.7.36-31.55"},
@@ -287,6 +296,8 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"5.7.28-31.41.2", "1.6.0", nil, "5.7.28-31.41.2"},
 		{"5.7.28-31.41.2", "1.5.0", nil, "5.7.28-31.41.2"},
 		{"5.7.28-31.41.2", "1.4.0", nil, "5.7.28-31.41.2"},
+		{"8.4.5-5.1", "1.18.0", nil, "8.4.5-5.1"},
+		{"8.0.36-28.1", "1.18.0", nil, "8.0.36-28.1"},
 		{"8.0.36-28.1", "1.17.0", nil, "8.0.36-28.1"},
 		{"8.0.36-28.1", "1.16.1", nil, "8.0.36-28.1"},
 		{"8.0.36-28.1", "1.16.0", nil, "8.0.36-28.1"},
@@ -306,6 +317,8 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"8.0.18-9.3", "1.4.0", nil, "8.0.18-9.3"},
 
 		//test with suffix
+		{"8.4-latest", "1.18.0", nil, "8.4.5-5.1"},
+		{"8.0-latest", "1.18.0", nil, "8.0.42-33.1"},
 		{"8.0-latest", "1.17.0", nil, "8.0.41-32.1"},
 		{"8.0-latest", "1.16.1", nil, "8.0.39-30.1"},
 		{"8.0-latest", "1.16.0", nil, "8.0.39-30.1"},
@@ -323,6 +336,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"8.0-latest", "1.6.0", nil, "8.0.20-11.2"},
 		{"8.0-latest", "1.5.0", nil, "8.0.20-11.2"},
 		{"8.0-latest", "1.4.0", nil, "8.0.18-9.3"},
+		{"5.7-latest", "1.18.0", nil, "5.7.44-31.65"},
 		{"5.7-latest", "1.17.0", nil, "5.7.44-31.65"},
 		{"5.7-latest", "1.16.1", nil, "5.7.44-31.65"},
 		{"5.7-latest", "1.16.0", nil, "5.7.44-31.65"},
@@ -340,6 +354,8 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"5.7-latest", "1.6.0", nil, "5.7.31-31.45.2"},
 		{"5.7-latest", "1.5.0", nil, "5.7.31-31.45.2"},
 		{"5.7-latest", "1.4.0", nil, "5.7.28-31.41.2"},
+		// 8.4-recommended is skipped as not recommended now
+		{"8.0-recommended", "1.18.0", nil, "8.0.42-33.1"},
 		{"8.0-recommended", "1.17.0", nil, "8.0.41-32.1"},
 		{"8.0-recommended", "1.16.1", nil, "8.0.39-30.1"},
 		{"8.0-recommended", "1.16.0", nil, "8.0.39-30.1"},
@@ -357,6 +373,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"8.0-recommended", "1.6.0", nil, "8.0.20-11.2"},
 		{"8.0-recommended", "1.5.0", nil, "8.0.20-11.2"},
 		{"8.0-recommended", "1.4.0", nil, "8.0.18-9.3"},
+		{"5.7-recommended", "1.18.0", nil, "5.7.44-31.65"},
 		{"5.7-recommended", "1.17.0", nil, "5.7.44-31.65"},
 		{"5.7-recommended", "1.16.1", nil, "5.7.44-31.65"},
 		{"5.7-recommended", "1.16.0", nil, "5.7.44-31.65"},

--- a/api-tests/operator_route_test.go
+++ b/api-tests/operator_route_test.go
@@ -33,6 +33,7 @@ func TestOperatorRouteShouldReturnRightOperatorVersion(t *testing.T) {
 		{"pxc-operator", "1.16.0"},
 		{"pxc-operator", "1.16.1"},
 		{"pxc-operator", "1.17.0"},
+		{"pxc-operator", "1.18.0"},
 		{"psmdb-operator", "1.5.0"},
 		{"psmdb-operator", "1.6.0"},
 		{"psmdb-operator", "1.7.0"},
@@ -118,6 +119,7 @@ func TestOperatorRoutePxcShouldReturnNotEmptyResponses(t *testing.T) {
 		{"pxc-operator", "1.16.0"},
 		{"pxc-operator", "1.16.1"},
 		{"pxc-operator", "1.17.0"},
+		{"pxc-operator", "1.18.0"},
 	}
 
 	for _, c := range cases {

--- a/server/filters_test.go
+++ b/server/filters_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pbVersion "github.com/Percona-Lab/percona-version-service/versionpb/api"
+)
+
+func TestPMMFilter(t *testing.T) {
+	tests := map[string]struct {
+		versions map[string]*pbVersion.Version
+		expected map[string]*pbVersion.Version
+	}{
+		"no versions": {
+			versions: map[string]*pbVersion.Version{},
+			expected: map[string]*pbVersion.Version{},
+		},
+		"single PMM2 version": {
+			versions: map[string]*pbVersion.Version{
+				"2.44.1-1": nil,
+			},
+			expected: map[string]*pbVersion.Version{
+				"2.44.1-1": nil,
+			},
+		},
+		"multiple PMM2 versions": {
+			versions: map[string]*pbVersion.Version{
+				"2.43.0":   nil,
+				"2.44.0":   nil,
+				"2.44.1-1": nil,
+			},
+			expected: map[string]*pbVersion.Version{
+				"2.44.1-1": nil,
+			},
+		},
+		"single PMM3 version": {
+			versions: map[string]*pbVersion.Version{
+				"3.3.1": nil,
+			},
+			expected: map[string]*pbVersion.Version{
+				"3.3.1": nil,
+			},
+		},
+		"multiple PMM3 versions": {
+			versions: map[string]*pbVersion.Version{
+				"3.2.0": nil,
+				"3.3.0": nil,
+				"3.3.1": nil,
+			},
+			expected: map[string]*pbVersion.Version{
+				"3.3.1": nil,
+			},
+		},
+		"one PMM2 and one PMM3 version": {
+			versions: map[string]*pbVersion.Version{
+				"2.44.1-1": nil,
+				"3.3.1":    nil,
+			},
+			expected: map[string]*pbVersion.Version{
+				"2.44.1-1": nil,
+				"3.3.1":    nil,
+			},
+		},
+		"multiple PMM2 and PMM3 versions": {
+			versions: map[string]*pbVersion.Version{
+				"2.43.0":   nil,
+				"2.44.0":   nil,
+				"2.44.1-1": nil,
+				"3.2.0":    nil,
+				"3.3.0":    nil,
+				"3.3.1":    nil,
+			},
+			expected: map[string]*pbVersion.Version{
+				"2.44.1-1": nil,
+				"3.3.1":    nil,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := pmmFilter(tt.versions, true)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, tt.versions)
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -182,11 +182,7 @@ func pxc(vs *pbVersion.VersionResponse, deps Deps, req *pbVersion.ApplyRequest) 
 		return err
 	}
 
-	pmmVersion, err := depFilter(deps.PMM, productVersion)
-	if err != nil {
-		return err
-	}
-	err = defaultFilter(vs.Versions[0].Matrix.Pmm, pmmVersion, true)
+	err = pmmFilter(vs.Versions[0].Matrix.Pmm, true)
 	if err != nil {
 		return err
 	}
@@ -242,11 +238,7 @@ func psmdb(vs *pbVersion.VersionResponse, deps Deps, req *pbVersion.ApplyRequest
 		return err
 	}
 
-	pmmVersion, err := depFilter(deps.PMM, productVersion)
-	if err != nil {
-		return err
-	}
-	err = defaultFilter(vs.Versions[0].Matrix.Pmm, pmmVersion, true)
+	err = pmmFilter(vs.Versions[0].Matrix.Pmm, true)
 	if err != nil {
 		return err
 	}
@@ -307,6 +299,11 @@ func pg(vs *pbVersion.VersionResponse, deps Deps, req *pbVersion.ApplyRequest) e
 		return err
 	}
 	err = defaultFilter(vs.Versions[0].Matrix.Postgis, depVer, true)
+	if err != nil {
+		return err
+	}
+
+	err = pmmFilter(vs.Versions[0].Matrix.Pmm, true)
 	if err != nil {
 		return err
 	}

--- a/sources/operator.1.18.0.pxc-operator.dep.json
+++ b/sources/operator.1.18.0.pxc-operator.dep.json
@@ -1,0 +1,52 @@
+{
+  "backup": {
+    "8.4.0": {
+      ">=": [
+        {
+          "var": "productVersion"
+        },
+        "8.4"
+      ]
+    },
+    "8.0.35": {
+      "and": [
+        {
+          ">=": [
+            {
+              "var": "productVersion"
+            },
+            "8.0"
+          ]
+        },
+        {
+          "<": [
+            {
+              "var": "productVersion"
+            },
+            "8.4"
+          ]
+        }
+      ]
+    },
+    "2.4.29": {
+      "and": [
+        {
+          ">=": [
+            {
+              "var": "productVersion"
+            },
+            "5.7"
+          ]
+        },
+        {
+          "<": [
+            {
+              "var": "productVersion"
+            },
+            "8.0"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/sources/operator.1.18.0.pxc-operator.json
+++ b/sources/operator.1.18.0.pxc-operator.json
@@ -1,0 +1,145 @@
+{
+  "versions": [
+    {
+      "operator": "1.18.0",
+      "product": "pxc-operator",
+      "matrix": {
+        "pxc": {
+          "8.4.5-5.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.4.5-5.1",
+            "image_hash": "918c54c11c96bf61bb3f32315ef6b344b7b1d68a0457a47a3804eca3932b2b17",
+            "status": "available",
+            "critical": false
+          },
+          "8.0.42-33.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.0.42-33.1",
+            "image_hash": "476851339090e44bb72760ae718fc36beb73a6028a29459e849271649018d546",
+            "status": "recommended",
+            "critical": false
+          },
+          "8.0.41-32.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.0.41-32.1",
+            "image_hash": "d9c84884a12631306d5a33a079e30bf7b65d3d380b07b397d7b1b6a642cc6bff",
+            "status": "available",
+            "critical": false
+          },
+          "8.0.39-30.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.0.39-30.1",
+            "image_hash": "6a53a6ad4e7d2c2fb404d274d993414a22cb67beecf7228df9d5d994e7a09966",
+            "status": "available",
+            "critical": false
+          },
+          "8.0.36-28.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.0.36-28.1",
+            "image_hash": "b5cc4034ccfb0186d6a734cb749ae17f013b027e9e64746b2c876e8beef379b3",
+            "status": "available",
+            "critical": false
+          },
+          "8.0.35-27.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.0.35-27.1",
+            "image_hash": "1ef24953591ef1c1ce39576843d5615d4060fd09458c7a39ebc3e2eda7ef486b",
+            "status": "available",
+            "critical": false
+          },
+          "5.7.44-31.65": {
+            "image_path": "percona/percona-xtradb-cluster:5.7.44-31.65",
+            "image_hash": "36fafdef46485839d4ff7c6dc73b4542b07031644c0152e911acb9734ff2be85",
+            "status": "recommended",
+            "critical": false
+          },
+          "5.7.42-31.65": {
+            "image_path": "percona/percona-xtradb-cluster:5.7.42-31.65",
+            "image_hash": "9dab86780f86ec9caf8e1032a563c131904b75a37edeaec159a93f7d0c16c603",
+            "status": "available",
+            "critical": false
+          },
+          "5.7.39-31.61": {
+            "image_path": "percona/percona-xtradb-cluster:5.7.39-31.61",
+            "image_hash": "9013170a71559bbac92ba9c2e986db9bda3a8a9e39ee1ee350e0ee94488bb6d7",
+            "status": "available",
+            "critical": false
+          },
+          "5.7.36-31.55": {
+            "image_path": "percona/percona-xtradb-cluster:5.7.36-31.55",
+            "image_hash": "c7bad990fc7ca0fde89240e921052f49da08b67c7c6dc54239593d61710be504",
+            "status": "available",
+            "critical": false
+          },
+          "5.7.34-31.51": {
+            "image_path": "percona/percona-xtradb-cluster:5.7.34-31.51",
+            "image_hash": "f8d51d7932b9bb1a5a896c7ae440256230eb69b55798ff37397aabfd58b80ccb",
+            "status": "available",
+            "critical": false
+          }
+        },
+        "pmm": {
+          "2.44.1-1": {
+            "image_path": "percona/pmm-client:2.44.1-1",
+            "image_hash": "52a8fb5e8f912eef1ff8a117ea323c401e278908ce29928dafc23fac1db4f1e3",
+            "status": "recommended",
+            "critical": false
+          },
+          "3.3.1": {
+            "image_hash": "29a9bb1c69fef8bedc4d4a9ed0ae8224a8623fd3eb8676ef40b13fd044188cb4",
+            "image_path": "percona/pmm-client:3.3.1",
+            "status": "recommended",
+            "critical": false
+          }
+        },
+        "proxysql": {
+          "2.7.3": {
+            "image_path": "percona/proxysql2:2.7.3",
+            "image_hash": "51fedf9de05e4f130d5b08388511536fb1e1050a24ffc21bedb0f0b61a236567",
+            "status": "recommended",
+            "critical": false
+          }
+        },
+        "haproxy": {
+          "2.8.15": {
+            "image_path": "percona/haproxy:2.8.15",
+            "image_hash": "49e6987a1c8b27e9111ae1f1168dd51f2840eb6d939ffc157358f0f259819006",
+            "status": "recommended",
+            "critical": false
+          }
+        },
+        "backup": {
+          "8.4.0": {
+            "image_path": "percona/percona-xtrabackup:8.4.0-3.1",
+            "image_hash": "01071522753ad94e11a897859bba4713316d08e493e23555c0094d68da223730",
+            "status": "available",
+            "critical": false
+          },
+          "8.0.35": {
+            "image_path": "percona/percona-xtrabackup:8.0.35-34.1",
+            "image_hash": "2dc127b08971051296d421b22aa861bb0330cf702b4b0246ae31053b0f01911e",
+            "status": "recommended",
+            "critical": false
+          },
+          "2.4.29": {
+            "image_path": "percona/percona-xtrabackup:2.4.29",
+            "image_hash": "11b92a7f7362379fc6b0de92382706153f2ac007ebf0d7ca25bac2c7303fdf10",
+            "status": "recommended",
+            "critical": false
+          }
+        },
+        "log_collector": {
+          "4.0.1": {
+            "image_path": "percona/fluentbit:4.0.1",
+            "image_hash": "a4ab7dd10379ccf74607f6b05225c4996eeff53b628bda94e615781a1f58b779",
+            "status": "recommended",
+            "critical": false
+          }
+        },
+        "operator": {
+          "1.18.0": {
+            "image_path": "percona/percona-xtradb-cluster-operator:1.18.0",
+            "image_hash": "0eca0b096482c7d09792c15fee00dbdcd0fbf3cd487dab60eb2774b025681e85",
+            "image_hash_arm64": "bdb7a0ff6b78e98b16f8b521e91682202b6d404202283b34b8168013d5c06356",
+            "status": "recommended",
+            "critical": false
+          }
+        }
+      }
+    }
+  ]
+}

--- a/sources/operator.1.20.1.psmdb-operator.json
+++ b/sources/operator.1.20.1.psmdb-operator.json
@@ -81,13 +81,6 @@
           }
         },
         "pmm": {
-          "2.44.1": {
-            "image_path": "percona/pmm-client:2.44.1",
-            "image_hash": "8b2eaddffd626f02a2d5318ffebc0c277fe8457da6083b8cfcada9b6e6168616",
-            "image_hash_arm64": "337fecd4afdb3f6daf2caa2b341b9fe41d0418a0e4ec76980c7f29be9d08b5ea",
-            "status": "available",
-            "critical": false
-          },
           "2.44.1-1": {
             "image_path": "percona/pmm-client:2.44.1-1",
             "image_hash": "2f9c79934b85541afe815a1e1e58a03c66bf953abea3932ddd8486408b867c41",

--- a/sources/operator.2.7.0.pg-operator.json
+++ b/sources/operator.2.7.0.pg-operator.json
@@ -148,13 +148,6 @@
           }
         },
         "pmm": {
-          "2.44.1": {
-            "critical": false,
-            "image_hash": "8b2eaddffd626f02a2d5318ffebc0c277fe8457da6083b8cfcada9b6e6168616",
-            "image_hash_arm64": "337fecd4afdb3f6daf2caa2b341b9fe41d0418a0e4ec76980c7f29be9d08b5ea",
-            "image_path": "percona/pmm-client:2.44.1",
-            "status": "available"
-          },
           "2.44.1-1": {
             "image_path": "percona/pmm-client:2.44.1-1",
             "image_hash": "2f9c79934b85541afe815a1e1e58a03c66bf953abea3932ddd8486408b867c41",


### PR DESCRIPTION
* Update PXC operator with 1.18.0 images

* Add 8.4 support

* Add PMM3 support 
---------

Co-authored-by: Ege Güneş <ege.gunes@percona.com>