### PR TITLE
K8SPXC-1857 Update PXC Operator versions for 1.19.1 release (#517)

### DIFF
--- a/api-tests/apply_route_test.go
+++ b/api-tests/apply_route_test.go
@@ -92,7 +92,7 @@ func TestApplyPxcShouldReturnSameMajorVersion(t *testing.T) {
 
 	pxcParams := &version_service.VersionServiceApplyParams{
 		Apply:           "latest",
-		OperatorVersion: "1.19.0",
+		OperatorVersion: "1.19.1",
 		Product:         "pxc-operator",
 	}
 	pxcParams.WithTimeout(2 * time.Second)
@@ -182,6 +182,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		version   string
 	}{
 		// test latest
+		{"latest", "1.19.1", nil, "8.4.7-7.1"},
 		{"latest", "1.19.0", nil, "8.4.7-7.1"},
 		{"latest", "1.18.0", nil, "8.4.5-5.1"},
 		{"latest", "1.17.0", nil, "8.0.41-32.1"},
@@ -201,9 +202,12 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"latest", "1.6.0", nil, "8.0.20-11.2"},
 		{"latest", "1.5.0", nil, "8.0.20-11.2"},
 		{"latest", "1.4.0", nil, "8.0.18-9.3"},
+		{"latest", "1.19.1", &v84, "8.4.7-7.1"},
 		{"latest", "1.19.0", &v84, "8.4.7-7.1"},
+		{"latest", "1.19.1", &v80, "8.0.44-35.1"},
 		{"latest", "1.19.0", &v80, "8.0.44-35.1"},
 		{"latest", "1.18.0", &v80, "8.0.42-33.1"},
+		{"latest", "1.19.1", &v57, "5.7.44-31.65"},
 		{"latest", "1.19.0", &v57, "5.7.44-31.65"},
 		{"latest", "1.18.0", &v57, "5.7.44-31.65"},
 		{"latest", "1.17.0", &v57, "5.7.44-31.65"},
@@ -225,6 +229,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"latest", "1.4.0", &v57, "5.7.28-31.41.2"},
 
 		// test latest when prerelease part in current version is bigger than in latest
+		{"latest", "1.19.1", &vPreRel, "5.7.44-31.65"},
 		{"latest", "1.19.0", &vPreRel, "5.7.44-31.65"},
 		{"latest", "1.18.0", &vPreRel, "5.7.44-31.65"},
 		{"latest", "1.17.0", &vPreRel, "5.7.44-31.65"},
@@ -245,6 +250,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"latest", "1.5.0", &vPreRel, "5.7.31-31.45.2"},
 
 		// test recommended
+		{"recommended", "1.19.1", nil, "8.4.7-7.1"},
 		{"recommended", "1.19.0", nil, "8.4.7-7.1"},
 		{"recommended", "1.18.0", nil, "8.0.42-33.1"},
 		{"recommended", "1.17.0", nil, "8.0.41-32.1"},
@@ -264,9 +270,12 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"recommended", "1.6.0", nil, "8.0.20-11.2"},
 		{"recommended", "1.5.0", nil, "8.0.20-11.2"},
 		{"recommended", "1.4.0", nil, "8.0.18-9.3"},
+		{"recommended", "1.19.1", &v84, "8.4.7-7.1"},
 		{"recommended", "1.19.0", &v84, "8.4.7-7.1"},
+		{"recommended", "1.19.1", &v80, "8.0.44-35.1"},
 		{"recommended", "1.19.0", &v80, "8.0.44-35.1"},
 		{"recommended", "1.18.0", &v80, "8.0.42-33.1"},
+		{"recommended", "1.19.1", &v57, "5.7.44-31.65"},
 		{"recommended", "1.19.0", &v57, "5.7.44-31.65"},
 		{"recommended", "1.18.0", &v57, "5.7.44-31.65"},
 		{"recommended", "1.17.0", &v57, "5.7.44-31.65"},
@@ -288,6 +297,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"recommended", "1.4.0", &v57, "5.7.28-31.41.2"},
 
 		// test exact
+		{"5.7.36-31.55", "1.19.1", nil, "5.7.36-31.55"},
 		{"5.7.36-31.55", "1.19.0", nil, "5.7.36-31.55"},
 		{"5.7.36-31.55", "1.18.0", nil, "5.7.36-31.55"},
 		{"5.7.36-31.55", "1.17.0", nil, "5.7.36-31.55"},
@@ -307,8 +317,10 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"5.7.28-31.41.2", "1.6.0", nil, "5.7.28-31.41.2"},
 		{"5.7.28-31.41.2", "1.5.0", nil, "5.7.28-31.41.2"},
 		{"5.7.28-31.41.2", "1.4.0", nil, "5.7.28-31.41.2"},
+		{"8.4.7-7.1", "1.19.1", nil, "8.4.7-7.1"},
 		{"8.4.7-7.1", "1.19.0", nil, "8.4.7-7.1"},
 		{"8.4.5-5.1", "1.18.0", nil, "8.4.5-5.1"},
+		{"8.0.44-35.1", "1.19.1", nil, "8.0.44-35.1"},
 		{"8.0.44-35.1", "1.19.0", nil, "8.0.44-35.1"},
 		{"8.0.36-28.1", "1.18.0", nil, "8.0.36-28.1"},
 		{"8.0.36-28.1", "1.17.0", nil, "8.0.36-28.1"},
@@ -330,8 +342,10 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"8.0.18-9.3", "1.4.0", nil, "8.0.18-9.3"},
 
 		//test with suffix
+		{"8.4-latest", "1.19.1", nil, "8.4.7-7.1"},
 		{"8.4-latest", "1.19.0", nil, "8.4.7-7.1"},
 		{"8.4-latest", "1.18.0", nil, "8.4.5-5.1"},
+		{"8.0-latest", "1.19.1", nil, "8.0.44-35.1"},
 		{"8.0-latest", "1.19.0", nil, "8.0.44-35.1"},
 		{"8.0-latest", "1.18.0", nil, "8.0.42-33.1"},
 		{"8.0-latest", "1.17.0", nil, "8.0.41-32.1"},
@@ -351,6 +365,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"8.0-latest", "1.6.0", nil, "8.0.20-11.2"},
 		{"8.0-latest", "1.5.0", nil, "8.0.20-11.2"},
 		{"8.0-latest", "1.4.0", nil, "8.0.18-9.3"},
+		{"5.7-latest", "1.19.1", nil, "5.7.44-31.65"},
 		{"5.7-latest", "1.19.0", nil, "5.7.44-31.65"},
 		{"5.7-latest", "1.18.0", nil, "5.7.44-31.65"},
 		{"5.7-latest", "1.17.0", nil, "5.7.44-31.65"},
@@ -370,8 +385,10 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"5.7-latest", "1.6.0", nil, "5.7.31-31.45.2"},
 		{"5.7-latest", "1.5.0", nil, "5.7.31-31.45.2"},
 		{"5.7-latest", "1.4.0", nil, "5.7.28-31.41.2"},
+		{"8.4-recommended", "1.19.1", nil, "8.4.7-7.1"},
 		{"8.4-recommended", "1.19.0", nil, "8.4.7-7.1"},
 		// 8.4-recommended is skipped for 1.18.0 and earlier as not recommended at that time
+		{"8.0-recommended", "1.19.1", nil, "8.0.44-35.1"},
 		{"8.0-recommended", "1.19.0", nil, "8.0.44-35.1"},
 		{"8.0-recommended", "1.18.0", nil, "8.0.42-33.1"},
 		{"8.0-recommended", "1.17.0", nil, "8.0.41-32.1"},
@@ -391,6 +408,7 @@ func TestApplyPxcReturnedVersions(t *testing.T) {
 		{"8.0-recommended", "1.6.0", nil, "8.0.20-11.2"},
 		{"8.0-recommended", "1.5.0", nil, "8.0.20-11.2"},
 		{"8.0-recommended", "1.4.0", nil, "8.0.18-9.3"},
+		{"5.7-recommended", "1.19.1", nil, "5.7.44-31.65"},
 		{"5.7-recommended", "1.19.0", nil, "5.7.44-31.65"},
 		{"5.7-recommended", "1.18.0", nil, "5.7.44-31.65"},
 		{"5.7-recommended", "1.17.0", nil, "5.7.44-31.65"},

--- a/api-tests/operator_route_test.go
+++ b/api-tests/operator_route_test.go
@@ -35,6 +35,7 @@ func TestOperatorRouteShouldReturnRightOperatorVersion(t *testing.T) {
 		{"pxc-operator", "1.17.0"},
 		{"pxc-operator", "1.18.0"},
 		{"pxc-operator", "1.19.0"},
+		{"pxc-operator", "1.19.1"},
 		{"psmdb-operator", "1.5.0"},
 		{"psmdb-operator", "1.6.0"},
 		{"psmdb-operator", "1.7.0"},
@@ -132,6 +133,7 @@ func TestOperatorRoutePxcShouldReturnNotEmptyResponses(t *testing.T) {
 		{"pxc-operator", "1.17.0"},
 		{"pxc-operator", "1.18.0"},
 		{"pxc-operator", "1.19.0"},
+		{"pxc-operator", "1.19.1"},
 	}
 
 	for _, c := range cases {

--- a/sources/operator.1.19.1.pxc-operator.dep.json
+++ b/sources/operator.1.19.1.pxc-operator.dep.json
@@ -1,0 +1,52 @@
+{
+  "backup": {
+    "8.4.0": {
+      ">=": [
+        {
+          "var": "productVersion"
+        },
+        "8.4"
+      ]
+    },
+    "8.0.35": {
+      "and": [
+        {
+          ">=": [
+            {
+              "var": "productVersion"
+            },
+            "8.0"
+          ]
+        },
+        {
+          "<": [
+            {
+              "var": "productVersion"
+            },
+            "8.4"
+          ]
+        }
+      ]
+    },
+    "2.4.29": {
+      "and": [
+        {
+          ">=": [
+            {
+              "var": "productVersion"
+            },
+            "5.7"
+          ]
+        },
+        {
+          "<": [
+            {
+              "var": "productVersion"
+            },
+            "8.0"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/sources/operator.1.19.1.pxc-operator.json
+++ b/sources/operator.1.19.1.pxc-operator.json
@@ -1,0 +1,160 @@
+{
+  "versions": [
+    {
+      "operator": "1.19.1",
+      "product": "pxc-operator",
+      "matrix": {
+        "pxc": {
+          "8.4.7-7.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.4.7-7.1",
+            "status": "recommended",
+            "critical": false,
+            "image_hash": "5b18775ad62a1c5f8d8bffc63a1518360d2e7a82c1bed7cbd8a15011f6cdff9f",
+            "image_hash_arm64": "4c3785f5befd001ca3ae035f42c9b586447b874158b0d9b26afb8ff87658829f"
+          },
+          "8.4.5-5.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.4.5-5.1",
+            "image_hash": "918c54c11c96bf61bb3f32315ef6b344b7b1d68a0457a47a3804eca3932b2b17",
+            "status": "available",
+            "critical": false
+          },
+          "8.0.44-35.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.0.44-35.1",
+            "status": "recommended",
+            "critical": false,
+            "image_hash": "34d7e23a42b9d009039a1a51f3068623320a002eac3498b0030cc3c6be0e36ac",
+            "image_hash_arm64": "4e1bb902cc8fb973134f828d05c785dd4fd32a94e30da773aadc8aab1f7e358a"
+          },
+          "8.0.42-33.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.0.42-33.1",
+            "image_hash": "629df45009f49f299ab333da33498c2bc4a3dcc75015b37bb622015c21b0ff9d",
+            "status": "available",
+            "critical": false
+          },
+          "8.0.41-32.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.0.41-32.1",
+            "image_hash": "d9c84884a12631306d5a33a079e30bf7b65d3d380b07b397d7b1b6a642cc6bff",
+            "status": "available",
+            "critical": false
+          },
+          "8.0.39-30.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.0.39-30.1",
+            "image_hash": "6a53a6ad4e7d2c2fb404d274d993414a22cb67beecf7228df9d5d994e7a09966",
+            "status": "available",
+            "critical": false
+          },
+          "8.0.36-28.1": {
+            "image_path": "percona/percona-xtradb-cluster:8.0.36-28.1",
+            "image_hash": "b5cc4034ccfb0186d6a734cb749ae17f013b027e9e64746b2c876e8beef379b3",
+            "status": "available",
+            "critical": false
+          },
+          "5.7.44-31.65": {
+            "image_path": "percona/percona-xtradb-cluster:5.7.44-31.65",
+            "image_hash": "36fafdef46485839d4ff7c6dc73b4542b07031644c0152e911acb9734ff2be85",
+            "status": "recommended",
+            "critical": false
+          },
+          "5.7.42-31.65": {
+            "image_path": "percona/percona-xtradb-cluster:5.7.42-31.65",
+            "image_hash": "9dab86780f86ec9caf8e1032a563c131904b75a37edeaec159a93f7d0c16c603",
+            "status": "available",
+            "critical": false
+          },
+          "5.7.39-31.61": {
+            "image_path": "percona/percona-xtradb-cluster:5.7.39-31.61",
+            "image_hash": "9013170a71559bbac92ba9c2e986db9bda3a8a9e39ee1ee350e0ee94488bb6d7",
+            "status": "available",
+            "critical": false
+          },
+          "5.7.36-31.55": {
+            "image_path": "percona/percona-xtradb-cluster:5.7.36-31.55",
+            "image_hash": "c7bad990fc7ca0fde89240e921052f49da08b67c7c6dc54239593d61710be504",
+            "status": "available",
+            "critical": false
+          },
+          "5.7.34-31.51": {
+            "image_path": "percona/percona-xtradb-cluster:5.7.34-31.51",
+            "image_hash": "f8d51d7932b9bb1a5a896c7ae440256230eb69b55798ff37397aabfd58b80ccb",
+            "status": "available",
+            "critical": false
+          }
+        },
+        "pmm": {
+          "2.44.1-1": {
+            "image_path": "percona/pmm-client:2.44.1-1",
+            "status": "recommended",
+            "critical": false,
+            "image_hash": "52a8fb5e8f912eef1ff8a117ea323c401e278908ce29928dafc23fac1db4f1e3",
+            "image_hash_arm64": "390bfd12f981e8b3890550c4927a3ece071377065e001894458047602c744e3b"
+          },
+          "3.5.0": {
+            "image_path": "percona/pmm-client:3.5.0",
+            "status": "recommended",
+            "critical": false,
+            "image_hash": "352aee74f25b3c1c4cd9dff1f378a0c3940b315e551d170c09953bf168531e4a",
+            "image_hash_arm64": "cbbb074d51d90a5f2d6f1d98a05024f6de2ffdcb5acab632324cea4349a820bd"
+          }
+        },
+        "proxysql": {
+          "2.7.3-1.2": {
+            "image_path": "percona/proxysql2:2.7.3-1.2",
+            "status": "recommended",
+            "critical": false,
+            "image_hash": "719d0ab363c65c7f75431bbed7ec0d9f2af7e691765c489da954813c552359a2",
+            "image_hash_arm64": "4c4d094652c9f2eb097be5d92dcc05da61c9e8699ac7321def959d5a205a89f7"
+          }
+        },
+        "haproxy": {
+          "2.8.17": {
+            "image_path": "percona/haproxy:2.8.17",
+            "status": "recommended",
+            "critical": false,
+            "image_hash": "ef8486b39a1e8dca97b5cdf1135e6282be1757ad188517b889d12c5a3470eeda",
+            "image_hash_arm64": "bbc5b3b66ac985d1a4500195539e7dff5196245a5a842a6858ea0848ec089967"
+          }
+        },
+        "backup": {
+          "8.4.0-5.1": {
+            "image_path": "percona/percona-xtrabackup:8.4.0-5.1",
+            "status": "recommended",
+            "critical": false,
+            "image_hash": "0f80a542a51af8733b5b5f1d836e72cfe9363250faa031ddec145f85206d6aac",
+            "image_hash_arm64": "22420a229d0b876331d0a2dd251a9e5060acaec2edc2eefc7384bd16516b6320"
+          },
+          "8.0.35-34.1": {
+            "image_path": "percona/percona-xtrabackup:8.0.35-34.1",
+            "status": "recommended",
+            "critical": false,
+            "image_hash": "967bafa0823c90aa8fa9c25a9012be36b0deef64e255294a09148d77ce6aea68",
+            "image_hash_arm64": "83f814dca9ed398b585938baa86508bda796ba301e34c948a5106095d27bf86e"
+          },
+          "2.4.29": {
+            "image_path": "percona/percona-xtrabackup:2.4.29",
+            "image_hash": "11b92a7f7362379fc6b0de92382706153f2ac007ebf0d7ca25bac2c7303fdf10",
+            "status": "recommended",
+            "critical": false
+          }
+        },
+        "log_collector": {
+          "4.0.1-1": {
+            "image_path": "percona/fluentbit:4.0.1-1",
+            "image_hash": "65bdf7d38cbceed6b6aa6412aea3fb4a196000ac6c66185f114a0a62c4a442ad",
+            "image_hash_arm64": "dabda77b298b67d30d7f53b5cdb7215ad19dabb22b9543e3fd8aedb74ab24733",
+            "status": "recommended",
+            "critical": false
+          }
+        },
+        "operator": {
+          "1.19.1": {
+            "image_path": "percona/percona-xtradb-cluster-operator:1.19.1",
+            "image_hash": "937a583f0031f45175aee2e5c7a380bbaa9a35046f0e7cae8cd900c44732c4f8",
+            "image_hash_arm64": "d1939659a5d331db9fae970dee42fd25f083d1955330e9043fe4cb862ff19326",
+            "status": "recommended",
+            "critical": false
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
* K8SPXC-1857 Update versions for PXC 1.19.1 release

* update tests

* update hashes

* update more hashes