### PR TITLE
Fix conflicted containers in Jenkins tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
                    sudo curl -SL "https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" -o /usr/local/bin/docker-compose
                    sudo chmod +x /usr/local/bin/docker-compose
 
+                   docker-compose -f docker-compose.test.yml down --volumes --remove-orphans || true
                    docker-compose -f docker-compose.test.yml up --build --abort-on-container-exit
                    '''
                 script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,7 @@ pipeline {
                 }
             }
             sh '''
+                docker-compose -f docker-compose.test.yml down --volumes --remove-orphans || true
                 sudo docker rmi -f \$(sudo docker images -q) || true
                 sudo rm -rf ./*
             '''

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,7 +21,6 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    container_name: version-service
     hostname: version-service
     networks:
       - integration-tests


### PR DESCRIPTION
**Problem:**

when re-running Jenkins pipeline, a conflict appears in Docker: 

```
14:15:40  Error response from daemon: Conflict. The container name "/version-service" is already in use by container "10205ea7c1f44231eb178a5732cb10a0ca6e7b4a7f57df8add4089aca6b560d6". You have to remove (or rename) that container to be able to reuse that name.
``` 

see the [run](https://cloud.cd.percona.com/job/pvs-pr-tests/view/change-requests/job/PR-557/4/console)
It blocks the CI, re-run helps only eventually when the other container is gone. 

The problem is that we use hardcoded container name which could conflict with a running/orphaned container. 

**Suggestion:** 
Do not hardcode the container name and clean up orphaned containers before each run. 